### PR TITLE
Revert "npm(deps-dev): bump electron from 11.1.1 to 11.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1429,9 +1429,9 @@
             }
         },
         "electron": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-11.2.0.tgz",
-            "integrity": "sha512-weszOPAJPoPu6ozL7vR9enXmaDSqH+KE9iZODfbGdnFgtVfVdfyedjlvEGIUJkLMPXM1y/QWwCl2dINzr0Jq5Q==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-11.1.1.tgz",
+            "integrity": "sha512-tlbex3xosJgfileN6BAQRotevPRXB/wQIq48QeQ08tUJJrXwE72c8smsM/hbHx5eDgnbfJ2G3a60PmRjHU2NhA==",
             "dev": true,
             "requires": {
                 "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "xvfb-maybe": "^0.2.1"
     },
     "devDependencies": {
-        "electron": "11.2.0",
+        "electron": "11.1.1",
         "electron-builder": "^22.9.1",
         "less": "^4.1.0",
         "mocha": "^8.2.1",


### PR DESCRIPTION
Electron `11.2.0` throws an ELIFECYCLE error.